### PR TITLE
match username exactly and support multiple search results

### DIFF
--- a/app/models/stern_insider_scraper.rb
+++ b/app/models/stern_insider_scraper.rb
@@ -76,14 +76,16 @@ class SternInsiderScraper
     else
       session.click_button "Go"
     end
-    tag = session
-      .find('span', text: username)
-      .send('parent') # div
-      .find('p.uppercase')
-      .text
-    if session.has_button?("Follow")
-      session.click_button "Follow"
+
+    # we want to match the username exactly, but allow for variations in case
+    user_row = session.find('span', exact_text: /#{username}/i).ancestor('li')
+
+    if user_row.has_button?("Follow")
+      user_row.click_button "Follow"
     end
+
+    tag = user_row.find('p.uppercase').text
+
     session.go_back
     tag
   rescue => e


### PR DESCRIPTION
the previous implementation would still match if the searched username was a subset of another username.

to fix this, we match exactly, and make sure that the elements we subsequently need belong to the row that we matched