### PR TITLE
Sync user data after player add

### DIFF
--- a/app/jobs/add_player_job.rb
+++ b/app/jobs/add_player_job.rb
@@ -3,7 +3,9 @@ class AddPlayerJob < ApplicationJob
 
   def perform(username)
     player = Syncer.add_player!(username)
-    SlackNotifier.send_message("Added #{username} as #{player.tag}")
+    SlackNotifier.send_message("Added #{username} as #{player.tag}. Syncing data...")
+
+    Syncer.sync!(notify: true, username: player.username)
   rescue => e
     # TODO: should probably have a "why" here???
     SlackNotifier.send_message(<<~EOF)

--- a/app/jobs/add_player_job.rb
+++ b/app/jobs/add_player_job.rb
@@ -4,5 +4,13 @@ class AddPlayerJob < ApplicationJob
   def perform(username)
     player = Syncer.add_player!(username)
     SlackNotifier.send_message("Added #{username} as #{player.tag}")
+  rescue => e
+    # TODO: should probably have a "why" here???
+    SlackNotifier.send_message(<<~EOF)
+      Failed to add #{username}.
+
+      This is either because the username was wrong, or that user doesn't have their stats visible to the public.
+      If this is you, you can go <https://insider.sternpinball.com/account/profile/stats|here> and make sure the checkbox is selected.
+    EOF
   end
 end

--- a/app/models/syncer.rb
+++ b/app/models/syncer.rb
@@ -7,8 +7,13 @@ class Syncer
     LOGGER.info("Login successful")
     n = 3
     current_leaderboard = AsciiLeaderboard.top(n: n)
-    Player.all.each do |player|
-      next if username && player.username != username
+    players = if username.present?
+      Player.where(username:)
+    else
+      Player.all
+    end
+
+    players.each do |player|
       player_notify = notify && !player.synced_at
       who = player.username
       LOGGER.info("Scraping stats for #{who}")


### PR DESCRIPTION
- do a sync straight away when we add a player. players wanna see their scores once they add themselves
- provide some feedback if the add fails. provide some simple error remediation steps.